### PR TITLE
bug fixing r1-length and r2-length parameters in .yml and pipeline code

### DIFF
--- a/cellhub/pipeline_cellranger.py
+++ b/cellhub/pipeline_cellranger.py
@@ -241,14 +241,12 @@ def count(infile, outfile):
     # add read trimming if specified
     r1len, r2len = "", ""
 
-    if PARAMS["gex_r1-length"] != False:
-        r1len = PARAMS["gex_r1-length"]
+    if PARAMS["count_r1-length"] != False:
+        r1len = PARAMS["count_r1-length"]
     
-    if PARAMS["gex_r2-length"] != False:
-        r2len = PARAMS["gex_r2-length"]
+    if PARAMS["count_r2-length"] != False:
+        r2len = PARAMS["count_r2-length"]
  
-    print(r1len, r2len)
-
     # deal with flags
     nosecondary, nobam, includeintrons = "", "", ""
     
@@ -457,6 +455,15 @@ def tcr(infile, outfile):
     inner=""
     if PARAMS["vdj_t_inner-enrichment-primers"]:
         inner="--inner-enrichment-primers=" + PARAMS["vdj_t_inner-enrichment-primers"]
+           
+    # add read trimming if specified
+    r1len, r2len = "", ""
+    
+    if PARAMS["vdj_t_r1-length"] != False:
+        r1len = PARAMS["vdj_t_r1-length"]
+    
+    if PARAMS["vdj_t_r2-length"] != False:
+        r2len = PARAMS["vdj_t_r2-length"]
     
     sample_dict = S.get_samples_and_fastqs(library_id,"VDJ-T")
  
@@ -472,6 +479,7 @@ def tcr(infile, outfile):
                     --localcores=%(cellranger_localcores)s
                     --localmem=%(cellranger_localmem)s
                     %(inner)s
+                    %(r1len)s %(r2len)s
                     &> ../%(log_file)s
                  ''' % dict(PARAMS, 
                             **t.var, 
@@ -627,6 +635,15 @@ def bcr(infile, outfile):
     inner=""
     if PARAMS["vdj_b_inner-enrichment-primers"]:
         inner="--inner-enrichment-primers=" + PARAMS["vdj_b_inner-enrichment-primers"]
+        
+    # add read trimming if specified
+    r1len, r2len = "", ""
+    
+    if PARAMS["vdj_b_r1-length"] != False:
+        r1len = PARAMS["vdj_b_r1-length"]
+    
+    if PARAMS["vdj_b_r2-length"] != False:
+        r2len = PARAMS["vdj_b_r2-length"]
     
     sample_dict = S.get_samples_and_fastqs(library_id,"VDJ-B")
  
@@ -642,6 +659,7 @@ def bcr(infile, outfile):
                     --localcores=%(cellranger_localcores)s
                     --localmem=%(cellranger_localmem)s
                     %(inner)s
+                    %(r1len)s %(r2len)s
                     &> ../%(log_file)s
                  ''' % dict(PARAMS, 
                             **t.var, 

--- a/cellhub/pipeline_cellranger.py
+++ b/cellhub/pipeline_cellranger.py
@@ -241,12 +241,14 @@ def count(infile, outfile):
     # add read trimming if specified
     r1len, r2len = "", ""
 
-    if PARAMS["gex_r1-length"] != "false":
+    if PARAMS["gex_r1-length"] != False:
         r1len = PARAMS["gex_r1-length"]
     
-    if PARAMS["gex_r2-length"] != "false":
-        r1len = PARAMS["gex_r2-length"]
+    if PARAMS["gex_r2-length"] != False:
+        r2len = PARAMS["gex_r2-length"]
  
+    print(r1len, r2len)
+
     # deal with flags
     nosecondary, nobam, includeintrons = "", "", ""
     

--- a/cellhub/yaml/pipeline_cellranger.yml
+++ b/cellhub/yaml/pipeline_cellranger.yml
@@ -77,6 +77,9 @@ gex:
         # Default: true
         include-introns: true
 
+        r1-length: false
+        r2-length: false
+
         
 # Section describing configuration of Feature Barcode libraries only, unless otherwise specified.
 feature:

--- a/cellhub/yaml/pipeline_cellranger.yml
+++ b/cellhub/yaml/pipeline_cellranger.yml
@@ -77,9 +77,6 @@ gex:
         # Default: true
         include-introns: true
 
-        r1-length: false
-        r2-length: false
-
         
 # Section describing configuration of Feature Barcode libraries only, unless otherwise specified.
 feature:


### PR DESCRIPTION


A couple of bugs found when running cellranger count and speficying r1-length: "false" and r2-length: "false" in pipeline_cellranger.yml.

The issue is that iotools.py from cgat-core is used to process the PARAMS dict. The str2val function converts anything that is for example "false" to False. This resulted in the string "False" being substituted into the commandline status when the lengths were specified as "false" rather than "".

Also the pipeline looks for r1-length and r2-length in the gex: section of the yml rather than the count section so have copied this into the gex: section. Can probably remove from the count: section although haven't tested if it breaks anything downstream yet...
