### PR TITLE
cellbender allows setting learning rate per sample.

### DIFF
--- a/cellhub/pipeline_cellbender.py
+++ b/cellhub/pipeline_cellbender.py
@@ -113,6 +113,8 @@ def cellbender(infile, outfile):
    
     expected_cells = PARAMS[sample_key]["expected_cells"]
     total_droplets = PARAMS[sample_key]["total_droplets_included"]
+    learning_rate = PARAMS[sample_key].get("learning_rate", PARAMS["cellbender_learning_rate"])
+    print(f"Sample {sample}: {expected_cells}, {total_droplets}, {learning_rate}.")
     
 
     # remove path from outfile and log_file 
@@ -137,7 +139,7 @@ def cellbender(infile, outfile):
                  --checkpoint-mins=720
                  --cpu-threads=%(resources_ncpu)s
                  --estimator-multiple-cpu
-                 --learning-rate=%(cellbender_learning_rate)s
+                 --learning-rate=%(learning_rate)s
                  --low-count-threshold=%(cellbender_low_count_threshold)s
                  &> %(log_file_name)s;
               ''' % dict(PARAMS, **t.var, **locals())


### PR DESCRIPTION
Allow setting a learning rate per sample in pipeline_cellbender.py.
- If a `learning_rate` field is defined at the sample level, its value will be used.
- Otherwise, the global `learning_rate` specified at the cellbender level will apply.

Example YAML with sample-specific learning rates:
```yaml
cellbender:
    learning_rate: 1e-4
    # ... other parameters

samples:
    sample1:
        expected_cells: 1600
        total_droplets_included: 25000
        learning_rate: 1e-5 # Overrides global
    sample2:
        expected_cells: 1500
        total_droplets_included: 20000
        # no learning rate => uses global 1e-4
    # ... other samples
```